### PR TITLE
Update readme.md to fix broken demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The formula for the HardeningKitty Score is _(Points achieved / Maximum points) 
 
 ## HardeningKitty Interface
 
-[ataumo](https://github.com/ataumo) build a web based interface for HardeningKitty. The tool can be used to create your own lists and provides additional information on the hardening settings. The [source code](https://github.com/ataumo/windows_hardening_interface) is under AGPL license and there is a [demo site](https://ataumo-photo.fr/windows_hardening_interface/).
+[ataumo](https://github.com/ataumo) build a web based interface for HardeningKitty. The tool can be used to create your own lists and provides additional information on the hardening settings. The [source code](https://github.com/ataumo/windows_hardening_interface) is under AGPL license and there is a [demo site](https://ataumo-photo.fr/policies_hardening_interface/interface/windows/).
 
 ## Last Update
 


### PR DESCRIPTION
The current demo link for the HardeningKitty Interface is broken - this updates it to a working URL for the Windows version