### PR TITLE
Update Invoke-HardeningKitty.ps1 for Windows server 2019 finding list

### DIFF
--- a/Invoke-HardeningKitty.ps1
+++ b/Invoke-HardeningKitty.ps1
@@ -1318,13 +1318,15 @@
                 # 
                 # Exception handling for special registry keys
                 # Machine => Network access: Remotely accessible registry paths
-                # Hardened UNC Paths => Remove spaces in result and recommendation
+                # Hardened UNC Paths => Remove spaces in result and recommendation only if result is not null or empty
                 #
                 If ($Finding.Method -eq 'Registry' -and $Finding.RegistryItem -eq "Machine"){
                     $Finding.RecommendedValue = $Finding.RecommendedValue.Replace(";"," ")
                 }
                 ElseIf ($Finding.Method -eq 'Registry' -and $Finding.RegistryPath -eq "HKLM:\Software\Policies\Microsoft\Windows\NetworkProvider\HardenedPaths") {
-                    $Result = $Result.Replace(" ","")
+                    If(![string]::IsNullOrEmpty($result)){
+						$Result = $Result.Replace(" ","")
+					}
                     $Finding.RecommendedValue = $Finding.RecommendedValue.Replace(" ","")
                 }              
  


### PR DESCRIPTION
I update the Powershell script. I update the comment and I verify with a function the $result.
I am figuring out that $Result can appear null or empty and cause a bug.
You can quickly debug with echo "$result" that will appear empty

The bug is in the Powershell script at line 1327: 
```
"You cannot call a method on a null-valued expression.
-> Details here: 
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : InvokeMethodOnNull"
```

This bug can be replicated using the finding list cis_microsoft_windows_server_2019_1809_1.2.1_machine.csv on a windows server 2019 environment.
It will appear on the ID: 
- [$] ID 18.5.11.4
- [$] ID 18.5.14.1.1